### PR TITLE
Changed Python to build as dynamic library

### DIFF
--- a/scripts/Ubuntu/common.sh
+++ b/scripts/Ubuntu/common.sh
@@ -716,7 +716,7 @@ function install_pythons(){
             { echo "[WARNING] Cannot unpack Python ${i}."; continue; }
         PY_PATH=${HOME}/.localpython${i}
         mkdir -p "${PY_PATH}"
-        ./configure --silent "--prefix=${PY_PATH}" &&
+        ./configure --enable-shared --silent "--prefix=${PY_PATH}" &&
         make --silent &&
         make install --silent >/dev/null ||
             { echo "[WARNING] Cannot make Python ${i}."; popd; continue; }


### PR DESCRIPTION
Typically python is built with the "enable-shared" flag. The MacOS image does so already. This will allow users to build C-Extensions for python without having to rebuild it.

I am currently having to rebuild python for Linux with this flag (which I don't have to do on mac or windows).