### PR TITLE
Update CMake URLs for 3.20 release

### DIFF
--- a/scripts/Ubuntu/common.sh
+++ b/scripts/Ubuntu/common.sh
@@ -1517,7 +1517,7 @@ function install_cmake() {
     else
         VERSION=$1
     fi
-    local TAR_FILE=cmake-${VERSION}-Linux-x86_64.tar.gz
+    local TAR_FILE=cmake-${VERSION}-linux-x86_64.tar.gz
     local TMP_DIR
     TMP_DIR=$(mktemp -d)
     pushd -- "${TMP_DIR}"

--- a/scripts/Windows/install_cmake.ps1
+++ b/scripts/Windows/install_cmake.ps1
@@ -15,7 +15,7 @@ $msiPath = "$env:TEMP\cmake-$cmakeVersion-win32-x86.msi"
 
 Write-Host "Downloading..."
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-(New-Object Net.WebClient).DownloadFile("https://github.com/Kitware/CMake/releases/download/v$cmakeVersion/cmake-$cmakeVersion-win32-x86.msi", $msiPath)
+(New-Object Net.WebClient).DownloadFile("https://github.com/Kitware/CMake/releases/download/v$cmakeVersion/cmake-$cmakeVersion-windows-x86_64.msi", $msiPath)
 
 Write-Host "Installing..."
 cmd /c start /wait msiexec /i $msiPath /quiet

--- a/scripts/Windows/install_cmake.ps1
+++ b/scripts/Windows/install_cmake.ps1
@@ -1,6 +1,6 @@
 ﻿$cmakeVersion = "3.20.1"
 
-$cmakeUninstallPath = "${env:ProgramFiles(x86)}\CMake\Uninstall.exe"
+$cmakeUninstallPath = "${env:ProgramFiles}\CMake\Uninstall.exe"
 if([IO.File]::Exists($cmakeUninstallPath)) {
     Write-Host "Uninstalling previous CMake ..." -ForegroundColor Cyan
     # uninstall existent
@@ -11,7 +11,7 @@ if([IO.File]::Exists($cmakeUninstallPath)) {
 }
 
 Write-Host "Installing CMake $cmakeVersion ..." -ForegroundColor Cyan
-$msiPath = "$env:TEMP\cmake-$cmakeVersion-win32-x86.msi"
+$msiPath = "$env:TEMP\cmake-$cmakeVersion-windows-x86_64.msi"
 
 Write-Host "Downloading..."
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
@@ -21,7 +21,7 @@ Write-Host "Installing..."
 cmd /c start /wait msiexec /i $msiPath /quiet
 Remove-Item $msiPath
 
-Add-Path "${env:ProgramFiles(x86)}\CMake\bin"
+Add-Path "${env:ProgramFiles}\CMake\bin"
 
 remove-path 'C:\ProgramData\chocolatey\bin'
 add-path 'C:\ProgramData\chocolatey\bin'


### PR DESCRIPTION
Succeeds #75. Updates the download URLs for CMake 3.20 and now installs the 64-bit version of CMake on Windows.

See https://cmake.org/cmake/help/latest/release/3.20.html#id19