### PR TITLE
docker-build to use plain output format by default

### DIFF
--- a/scripts/Ubuntu/common.sh
+++ b/scripts/Ubuntu/common.sh
@@ -503,6 +503,7 @@ SyslogIdentifier=appveyor-build-agent
 User=appveyor
 Environment=ASPNETCORE_ENVIRONMENT=Production
 Environment=TERM=xterm-256color
+Environment=BUILDKIT_PROGRESS=plain
 
 [Install]
 WantedBy=multi-user.target" > /etc/systemd/system/${SERVICE_NAME} &&

--- a/scripts/Windows/bootstrap/windows-bootstrap.ps1
+++ b/scripts/Windows/bootstrap/windows-bootstrap.ps1
@@ -128,6 +128,9 @@ if(-not $PSModulePath.contains($AppVeyorModulesPath)) {
     [Environment]::SetEnvironmentVariable('PSModulePath', "$PSModulePath;$AppVeyorModulesPath", 'Machine')
 }
 
+[Environment]::SetEnvironmentVariable('ASPNETCORE_ENVIRONMENT', 'Production')
+[Environment]::SetEnvironmentVariable('BUILDKIT_PROGRESS', 'plain')
+
 Write-Host "AppVeyor Build Agent installed" -ForegroundColor Green
 
 if ($build_agent_mode -eq 'Azure' -and $appveyor_url -and $appveyor_workerId) {

--- a/scripts/macos/common.sh
+++ b/scripts/macos/common.sh
@@ -792,7 +792,9 @@ function configure_autologin() {
 
 function configure_term() {
     echo "[INFO] Running configure_term..."
+    write_line "${HOME}/.profile" 'export ASPNETCORE_ENVIRONMENT=Production'
     write_line "${HOME}/.profile" 'export TERM=xterm-256color'
+    write_line "${HOME}/.profile" 'export BUILDKIT_PROGRESS=plain'
 }
 
 function enable_vnc() {


### PR DESCRIPTION
`docker build` clutters the https://ci.appveyor.com/ output. after discussion with docker folks https://github.com/moby/moby/discussions/47755 i found that it's best to set default output as plain text via BUILDKIT_PROGRESS=plain environment variable.