### PR TITLE
Add dotnet 9 SDK

### DIFF
--- a/scripts/Windows/install_dotnet_core_sdks.ps1
+++ b/scripts/Windows/install_dotnet_core_sdks.ps1
@@ -49,6 +49,7 @@ if ($vs2022) {
     Install-SDK "6.0.425"
     #Install-SDK "7.0.410"
     #Install-SDK "8.0.202"
+    Install-SDK "9.0.100"
 }
 
 # VS 2019 Preview


### PR DESCRIPTION
Unlike previous dotnet versions, dotnet 9 will only support VIsual Studio 2022 (specifically v17.12 or later)
[Version requirements for .NET 9 SDK](https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/9.0/version-requirements)