### PR TITLE
Fix "Daemons using outdated libraries" on Ubuntu 22.04

### DIFF
--- a/scripts/Ubuntu/common.sh
+++ b/scripts/Ubuntu/common.sh
@@ -388,6 +388,11 @@ function install_tools() {
         tools_array+=( "openssh-server" )
     fi
 
+    # Add release specific tools into tools_array
+    if command -v fix_apt_get_install; then
+        fix_apt_get_install
+    fi
+
     #APT_GET_OPTIONS="-o Debug::pkgProblemResolver=true -o Debug::Acquire::http=true"
     apt-get update
     apt-get -y ${APT_GET_OPTIONS-} install "${tools_array[@]}" --no-install-recommends ||

--- a/scripts/Ubuntu/jammy.sh
+++ b/scripts/Ubuntu/jammy.sh
@@ -12,6 +12,10 @@ function add_releasespecific_tools() {
     fi    
 }
 
+function fix_apt_get_install() {
+    sed -i "/#\$nrconf{restart} = 'i';/s/.*/\$nrconf{restart} = 'a';/" /etc/needrestart/needrestart.conf
+}
+
 function configure_mercurial_repository() {
     echo "[INFO] Running configure_mercurial_repository on Ubuntu 22.04...skipped"
 }


### PR DESCRIPTION
The issue: https://stackoverflow.com/questions/73397110/how-to-stop-ubuntu-pop-up-daemons-using-outdated-libraries-when-using-apt-to-i